### PR TITLE
Remove `install_requires`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,11 +70,6 @@ setup_args = dict(
     long_description_content_type="text/markdown",
     cmdclass=cmdclass,
     packages=setuptools.find_packages(),
-    install_requires=[
-        "jupyterlab>=3.0.0,==3.*",
-        "nbconvert==5.6.1",
-        "jedi==0.17.2"
-    ],
     zip_safe=False,
     include_package_data=True,
     python_requires=">=3.6",


### PR DESCRIPTION
The dependency on `nbconvert` is causing issues with the latest versions of `jupyter_server` which depend on a newer version:

```
ERROR: Cannot install -r requirements.txt (line 6) and jupyterlab because these package versions have conflicting dependencies.

The conflict is caused by:
    jupyterlab-legos-ui 0.1.7 depends on nbconvert==5.6.1
    jupyter-server 1.19.1 depends on nbconvert>=6.4.4
    jupyterlab-legos-ui 0.1.7 depends on nbconvert==5.6.1
    jupyter-server 1.19.0 depends on nbconvert>=6.4.4
    jupyterlab-legos-ui 0.1.7 depends on nbconvert==5.6.1
    jupyter-server 1.18.1 depends on nbconvert>=6.4.4
    jupyterlab-legos-ui 0.1.7 depends on nbconvert==5.6.1
    jupyter-server 1.18.0 depends on nbconvert>=6.4.4
    jupyterlab-legos-ui 0.1.7 depends on nbconvert==5.6.1
    jupyter-server 1.17.1 depends on nbconvert>=6.4.4
    jupyterlab-legos-ui 0.1.7 depends on nbconvert==5.6.1
    jupyter-server 1.17.0 depends on nbconvert>=6.4.4
    jupyterlab-legos-ui 0.1.7 depends on nbconvert==5.6.1
    jupyter-server 1.16.0 depends on nbconvert>=6.4.4
```

Also the other dependencies are not strictly needed to install the theme, so this PR removes them. That way it's aligned with the latest version of the cookiecutter: https://github.com/jupyterlab/extension-cookiecutter-ts/blob/468cc0b46bb8550a53c33fea60f4e7976e360143/%7B%7Bcookiecutter.python_name%7D%7D/pyproject.toml#L24-L26